### PR TITLE
Add completed emit call missing in emulateSlideFromProps

### DIFF
--- a/lib/SlideUnlock.vue
+++ b/lib/SlideUnlock.vue
@@ -225,8 +225,10 @@ export default defineComponent({
             Slider.ProgressWidth = computedPosition + (props.height / 2)
             Slider.HandlerPosition = computedPosition
             fadeText(true)
-            if (computedPosition >= sliderWidth.value - props.height)
-                complete()
+            if (computedPosition >= sliderWidth.value - props.height) {
+                complete();
+                passVerify();
+            }
         }
 
         watch(() => props.position, () => {


### PR DESCRIPTION
Currently the `@completed` event is only being emitted when the handler is manually moved but not when the slider is completed using emulation from position property. With this PR the event will be emitted in both cases.

Closes #37 